### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/421/171/549/421171549.geojson
+++ b/data/421/171/549/421171549.geojson
@@ -106,6 +106,9 @@
     },
     "wof:country":"ML",
     "wof:created":1459008897,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"bc4d9e64a4bb1161eaabd5728046ba3f",
     "wof:hierarchy":[
         {
@@ -116,7 +119,7 @@
         }
     ],
     "wof:id":421171549,
-    "wof:lastmodified":1566606399,
+    "wof:lastmodified":1582382267,
     "wof:name":"Kayes",
     "wof:parent_id":85674529,
     "wof:placetype":"county",

--- a/data/421/171/903/421171903.geojson
+++ b/data/421/171/903/421171903.geojson
@@ -89,6 +89,9 @@
     },
     "wof:country":"ML",
     "wof:created":1459008911,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4e70bc90aa8808adc4865a2372dfa0ed",
     "wof:hierarchy":[
         {
@@ -99,7 +102,7 @@
         }
     ],
     "wof:id":421171903,
-    "wof:lastmodified":1566606399,
+    "wof:lastmodified":1582382266,
     "wof:name":"Kenieba",
     "wof:parent_id":85674529,
     "wof:placetype":"county",

--- a/data/421/171/975/421171975.geojson
+++ b/data/421/171/975/421171975.geojson
@@ -109,6 +109,9 @@
     },
     "wof:country":"ML",
     "wof:created":1459008914,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"78eed4e8fe4409c61a5bf5b59459cbf8",
     "wof:hierarchy":[
         {
@@ -119,7 +122,7 @@
         }
     ],
     "wof:id":421171975,
-    "wof:lastmodified":1566606399,
+    "wof:lastmodified":1582382267,
     "wof:name":"Bandiagara",
     "wof:parent_id":85674539,
     "wof:placetype":"county",

--- a/data/421/172/359/421172359.geojson
+++ b/data/421/172/359/421172359.geojson
@@ -120,6 +120,9 @@
     },
     "wof:country":"ML",
     "wof:created":1459008937,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2aa1107a29b135a38e2c1e735d72dbe0",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
         }
     ],
     "wof:id":421172359,
-    "wof:lastmodified":1566606396,
+    "wof:lastmodified":1582382266,
     "wof:name":"Dire",
     "wof:parent_id":85674511,
     "wof:placetype":"county",

--- a/data/421/175/221/421175221.geojson
+++ b/data/421/175/221/421175221.geojson
@@ -102,6 +102,9 @@
     },
     "wof:country":"ML",
     "wof:created":1459009060,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"124b5a2735ea99d5ffcb83e4231055f0",
     "wof:hierarchy":[
         {
@@ -112,7 +115,7 @@
         }
     ],
     "wof:id":421175221,
-    "wof:lastmodified":1566606396,
+    "wof:lastmodified":1582382266,
     "wof:name":"Segou",
     "wof:parent_id":85674543,
     "wof:placetype":"county",

--- a/data/421/177/883/421177883.geojson
+++ b/data/421/177/883/421177883.geojson
@@ -70,6 +70,9 @@
     },
     "wof:country":"ML",
     "wof:created":1459009163,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4746b99bec0b3ec674e01d1a6540009f",
     "wof:hierarchy":[
         {
@@ -80,7 +83,7 @@
         }
     ],
     "wof:id":421177883,
-    "wof:lastmodified":1566606398,
+    "wof:lastmodified":1582382266,
     "wof:name":"Kati",
     "wof:parent_id":85674547,
     "wof:placetype":"county",

--- a/data/421/177/885/421177885.geojson
+++ b/data/421/177/885/421177885.geojson
@@ -195,6 +195,9 @@
     },
     "wof:country":"ML",
     "wof:created":1459009163,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"fa534a1756705cd5fa61e9220cbb2063",
     "wof:hierarchy":[
         {
@@ -205,7 +208,7 @@
         }
     ],
     "wof:id":421177885,
-    "wof:lastmodified":1566606398,
+    "wof:lastmodified":1582382266,
     "wof:name":"Koutiala",
     "wof:parent_id":85674531,
     "wof:placetype":"county",

--- a/data/421/180/081/421180081.geojson
+++ b/data/421/180/081/421180081.geojson
@@ -106,6 +106,9 @@
     },
     "wof:country":"ML",
     "wof:created":1459009243,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b5272efb862bc3bcd91aa1b799883862",
     "wof:hierarchy":[
         {
@@ -116,7 +119,7 @@
         }
     ],
     "wof:id":421180081,
-    "wof:lastmodified":1566606396,
+    "wof:lastmodified":1582382266,
     "wof:name":"Mopti",
     "wof:parent_id":85674539,
     "wof:placetype":"county",

--- a/data/421/182/167/421182167.geojson
+++ b/data/421/182/167/421182167.geojson
@@ -602,6 +602,9 @@
     ],
     "wof:country":"ML",
     "wof:created":1459009321,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"19b0d3a91d98e7be5b93b17526072b04",
     "wof:hierarchy":[
         {
@@ -613,7 +616,7 @@
         }
     ],
     "wof:id":421182167,
-    "wof:lastmodified":1566606398,
+    "wof:lastmodified":1582382266,
     "wof:name":"Bamako",
     "wof:parent_id":421187095,
     "wof:placetype":"locality",

--- a/data/421/184/495/421184495.geojson
+++ b/data/421/184/495/421184495.geojson
@@ -122,6 +122,9 @@
     },
     "wof:country":"ML",
     "wof:created":1459009412,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"58e19382afbad3ce5bc3a4f17fe377db",
     "wof:hierarchy":[
         {
@@ -132,7 +135,7 @@
         }
     ],
     "wof:id":421184495,
-    "wof:lastmodified":1566606398,
+    "wof:lastmodified":1582382266,
     "wof:name":"Koro",
     "wof:parent_id":85674539,
     "wof:placetype":"county",

--- a/data/421/187/095/421187095.geojson
+++ b/data/421/187/095/421187095.geojson
@@ -64,6 +64,9 @@
     },
     "wof:country":"ML",
     "wof:created":1459009501,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"19b0d3a91d98e7be5b93b17526072b04",
     "wof:hierarchy":[
         {
@@ -74,7 +77,7 @@
         }
     ],
     "wof:id":421187095,
-    "wof:lastmodified":1537303681,
+    "wof:lastmodified":1582382266,
     "wof:name":"Bamako",
     "wof:parent_id":85674525,
     "wof:placetype":"county",

--- a/data/421/187/097/421187097.geojson
+++ b/data/421/187/097/421187097.geojson
@@ -225,6 +225,9 @@
     },
     "wof:country":"ML",
     "wof:created":1459009502,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e98b909cd3bd364d19a9711d099631e3",
     "wof:hierarchy":[
         {
@@ -235,7 +238,7 @@
         }
     ],
     "wof:id":421187097,
-    "wof:lastmodified":1566606396,
+    "wof:lastmodified":1582382266,
     "wof:name":"Djenne",
     "wof:parent_id":85674539,
     "wof:placetype":"county",

--- a/data/421/192/717/421192717.geojson
+++ b/data/421/192/717/421192717.geojson
@@ -70,6 +70,9 @@
     },
     "wof:country":"ML",
     "wof:created":1459009746,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"76d90859399fb08f8217680f5c3cfa5a",
     "wof:hierarchy":[
         {
@@ -80,7 +83,7 @@
         }
     ],
     "wof:id":421192717,
-    "wof:lastmodified":1566606394,
+    "wof:lastmodified":1582382266,
     "wof:name":"San",
     "wof:parent_id":85674543,
     "wof:placetype":"county",

--- a/data/421/199/969/421199969.geojson
+++ b/data/421/199/969/421199969.geojson
@@ -105,6 +105,9 @@
     },
     "wof:country":"ML",
     "wof:created":1459010006,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6eec021d23b3cc16161cc74e15ada69a",
     "wof:hierarchy":[
         {
@@ -116,7 +119,7 @@
         }
     ],
     "wof:id":421199969,
-    "wof:lastmodified":1566606398,
+    "wof:lastmodified":1582382266,
     "wof:name":"Ansongo",
     "wof:parent_id":890418903,
     "wof:placetype":"localadmin",

--- a/data/421/199/983/421199983.geojson
+++ b/data/421/199/983/421199983.geojson
@@ -104,6 +104,9 @@
     },
     "wof:country":"ML",
     "wof:created":1459010007,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"004d40741b66ceb40548515be974f2d3",
     "wof:hierarchy":[
         {
@@ -114,7 +117,7 @@
         }
     ],
     "wof:id":421199983,
-    "wof:lastmodified":1566606397,
+    "wof:lastmodified":1582382266,
     "wof:name":"Douentza",
     "wof:parent_id":85674539,
     "wof:placetype":"county",

--- a/data/421/203/311/421203311.geojson
+++ b/data/421/203/311/421203311.geojson
@@ -341,6 +341,9 @@
     },
     "wof:country":"ML",
     "wof:created":1459010147,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"c47dd495460bc096edd4e51f349e9604",
     "wof:hierarchy":[
         {
@@ -352,7 +355,7 @@
         }
     ],
     "wof:id":421203311,
-    "wof:lastmodified":1566606396,
+    "wof:lastmodified":1582382266,
     "wof:name":"Gao",
     "wof:parent_id":890418899,
     "wof:placetype":"locality",

--- a/data/856/325/53/85632553.geojson
+++ b/data/856/325/53/85632553.geojson
@@ -918,6 +918,11 @@
     },
     "wof:country":"ML",
     "wof:country_alpha3":"MLI",
+    "wof:geom_alt":[
+        "meso",
+        "naturalearth",
+        "naturalearth-display-terrestrial-zoom6"
+    ],
     "wof:geomhash":"08a293f867d2b32d26b14f0611a9032d",
     "wof:hierarchy":[
         {
@@ -932,7 +937,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1566605771,
+    "wof:lastmodified":1582382252,
     "wof:name":"Mali",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/745/11/85674511.geojson
+++ b/data/856/745/11/85674511.geojson
@@ -284,6 +284,9 @@
         "wk:page":"Tombouctou Region"
     },
     "wof:country":"ML",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"632f0c88ec2874e8990a073f75499174",
     "wof:hierarchy":[
         {
@@ -299,7 +302,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1566605772,
+    "wof:lastmodified":1582382253,
     "wof:name":"Timbuktu",
     "wof:parent_id":85632553,
     "wof:placetype":"region",

--- a/data/856/745/15/85674515.geojson
+++ b/data/856/745/15/85674515.geojson
@@ -293,6 +293,9 @@
         "wk:page":"Kidal Region"
     },
     "wof:country":"ML",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a7c917390dcf1a0a0097c4db7394e289",
     "wof:hierarchy":[
         {
@@ -308,7 +311,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1566605774,
+    "wof:lastmodified":1582382254,
     "wof:name":"Kidal",
     "wof:parent_id":85632553,
     "wof:placetype":"region",

--- a/data/856/745/21/85674521.geojson
+++ b/data/856/745/21/85674521.geojson
@@ -279,6 +279,9 @@
         "wk:page":"Gao Region"
     },
     "wof:country":"ML",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f72196f93301d08d95895af099cb0e5d",
     "wof:hierarchy":[
         {
@@ -294,7 +297,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1566605773,
+    "wof:lastmodified":1582382253,
     "wof:name":"Gao",
     "wof:parent_id":85632553,
     "wof:placetype":"region",

--- a/data/856/745/25/85674525.geojson
+++ b/data/856/745/25/85674525.geojson
@@ -571,6 +571,9 @@
         421182167
     ],
     "wof:country":"ML",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"19b0d3a91d98e7be5b93b17526072b04",
     "wof:hierarchy":[
         {
@@ -586,7 +589,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1566605774,
+    "wof:lastmodified":1582382254,
     "wof:name":"Bamako",
     "wof:parent_id":85632553,
     "wof:placetype":"region",

--- a/data/856/745/29/85674529.geojson
+++ b/data/856/745/29/85674529.geojson
@@ -298,6 +298,9 @@
         "wk:page":"Kayes Region"
     },
     "wof:country":"ML",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"847bccace341bcff7c861608664f641e",
     "wof:hierarchy":[
         {
@@ -313,7 +316,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1566605772,
+    "wof:lastmodified":1582382253,
     "wof:name":"Kayes",
     "wof:parent_id":85632553,
     "wof:placetype":"region",

--- a/data/856/745/31/85674531.geojson
+++ b/data/856/745/31/85674531.geojson
@@ -295,6 +295,9 @@
         "wk:page":"Sikasso Region"
     },
     "wof:country":"ML",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b1077e57961b70bef2850aaf7df406ad",
     "wof:hierarchy":[
         {
@@ -310,7 +313,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1566605773,
+    "wof:lastmodified":1582382253,
     "wof:name":"Sikasso",
     "wof:parent_id":85632553,
     "wof:placetype":"region",

--- a/data/856/745/39/85674539.geojson
+++ b/data/856/745/39/85674539.geojson
@@ -301,6 +301,9 @@
         "wk:page":"Mopti Region"
     },
     "wof:country":"ML",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3570f2d6122f517b9cc1808c72524e28",
     "wof:hierarchy":[
         {
@@ -316,7 +319,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1566605773,
+    "wof:lastmodified":1582382254,
     "wof:name":"Mopti",
     "wof:parent_id":85632553,
     "wof:placetype":"region",

--- a/data/856/745/43/85674543.geojson
+++ b/data/856/745/43/85674543.geojson
@@ -305,6 +305,9 @@
         "wk:page":"S\u00e9gou Region"
     },
     "wof:country":"ML",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b89b3e2e5373a1916bbd29009beb12e7",
     "wof:hierarchy":[
         {
@@ -320,7 +323,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1566605773,
+    "wof:lastmodified":1582382253,
     "wof:name":"S\u00e9gou",
     "wof:parent_id":85632553,
     "wof:placetype":"region",

--- a/data/856/745/47/85674547.geojson
+++ b/data/856/745/47/85674547.geojson
@@ -299,6 +299,9 @@
         "wk:page":"Koulikoro Region"
     },
     "wof:country":"ML",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5491fb0706b250a63430eda1931499c9",
     "wof:hierarchy":[
         {
@@ -314,7 +317,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1566605774,
+    "wof:lastmodified":1582382254,
     "wof:name":"Koulikoro",
     "wof:parent_id":85632553,
     "wof:placetype":"region",

--- a/data/858/021/87/85802187.geojson
+++ b/data/858/021/87/85802187.geojson
@@ -77,6 +77,9 @@
         "qs:id":892311
     },
     "wof:country":"ML",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c1af43dcd346dae6b1a5277ff9657927",
     "wof:hierarchy":[
         {
@@ -92,7 +95,7 @@
     "wof:lang":[
         "fre"
     ],
-    "wof:lastmodified":1534379379,
+    "wof:lastmodified":1582382254,
     "wof:name":"Bozola",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/858/021/89/85802189.geojson
+++ b/data/858/021/89/85802189.geojson
@@ -73,6 +73,9 @@
         "qs:id":1096495
     },
     "wof:country":"ML",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"26b6022153ba5e8e0b966279be28b6f4",
     "wof:hierarchy":[
         {
@@ -88,7 +91,7 @@
     "wof:lang":[
         "fre"
     ],
-    "wof:lastmodified":1534379379,
+    "wof:lastmodified":1582382254,
     "wof:name":"Koulouba",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/858/021/95/85802195.geojson
+++ b/data/858/021/95/85802195.geojson
@@ -96,6 +96,9 @@
         "qs_pg:id":316779
     },
     "wof:country":"ML",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"048c4f95b49a32414542f3cb7e014479",
     "wof:hierarchy":[
         {
@@ -111,7 +114,7 @@
     "wof:lang":[
         "fre"
     ],
-    "wof:lastmodified":1566605775,
+    "wof:lastmodified":1582382254,
     "wof:name":"M\u00e9dina Koura",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/858/021/99/85802199.geojson
+++ b/data/858/021/99/85802199.geojson
@@ -80,6 +80,9 @@
         "qs:id":279408
     },
     "wof:country":"ML",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"be9cd0d549f82418d33e56a89159bc2d",
     "wof:hierarchy":[
         {
@@ -95,7 +98,7 @@
     "wof:lang":[
         "fre"
     ],
-    "wof:lastmodified":1534379379,
+    "wof:lastmodified":1582382254,
     "wof:name":"Missira",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/858/977/63/85897763.geojson
+++ b/data/858/977/63/85897763.geojson
@@ -70,6 +70,10 @@
         "qs_pg:id":219157
     },
     "wof:country":"ML",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"ac3a4f9ce9dd7a2bb64a4a41d64505c7",
     "wof:hierarchy":[
         {
@@ -84,7 +88,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566605774,
+    "wof:lastmodified":1582382254,
     "wof:name":"Il-G\u017cira",
     "wof:parent_id":101752431,
     "wof:placetype":"neighbourhood",

--- a/data/858/977/65/85897765.geojson
+++ b/data/858/977/65/85897765.geojson
@@ -72,6 +72,10 @@
         "qs_pg:id":211223
     },
     "wof:country":"ML",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"bff9bd6bae46967ce5839d6f9aa23fc5",
     "wof:hierarchy":[
         {
@@ -86,7 +90,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566605774,
+    "wof:lastmodified":1582382254,
     "wof:name":"Il-Kamp tal-Mellie\u0127a",
     "wof:parent_id":101848919,
     "wof:placetype":"neighbourhood",

--- a/data/858/977/69/85897769.geojson
+++ b/data/858/977/69/85897769.geojson
@@ -106,6 +106,9 @@
         "wk:page":"M\u0121arr, Gozo"
     },
     "wof:country":"ML",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0f8cdb34d0f8cd83bd20ddcd0ceea091",
     "wof:hierarchy":[
         {
@@ -120,7 +123,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566605774,
+    "wof:lastmodified":1582382254,
     "wof:name":"M\u0121arr",
     "wof:parent_id":101874857,
     "wof:placetype":"neighbourhood",

--- a/data/858/977/79/85897779.geojson
+++ b/data/858/977/79/85897779.geojson
@@ -75,6 +75,10 @@
         "qs_pg:id":900329
     },
     "wof:country":"ML",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"8dea64c44e4e648dd7d44cd9e98e9012",
     "wof:hierarchy":[
         {
@@ -89,7 +93,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566605775,
+    "wof:lastmodified":1582382254,
     "wof:name":"Vittoriosa",
     "wof:parent_id":101752423,
     "wof:placetype":"neighbourhood",

--- a/data/890/418/895/890418895.geojson
+++ b/data/890/418/895/890418895.geojson
@@ -92,6 +92,9 @@
     },
     "wof:country":"ML",
     "wof:created":1469051265,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8942d870dd7faff4b8a61d5f200c5b1e",
     "wof:hierarchy":[
         {
@@ -102,7 +105,7 @@
         }
     ],
     "wof:id":890418895,
-    "wof:lastmodified":1566606400,
+    "wof:lastmodified":1582382267,
     "wof:name":"Gourma-Rharous",
     "wof:parent_id":85674511,
     "wof:placetype":"county",

--- a/data/890/418/899/890418899.geojson
+++ b/data/890/418/899/890418899.geojson
@@ -89,6 +89,9 @@
     },
     "wof:country":"ML",
     "wof:created":1469051265,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2bf93d2d687b6b45602646316e3f837c",
     "wof:hierarchy":[
         {
@@ -99,7 +102,7 @@
         }
     ],
     "wof:id":890418899,
-    "wof:lastmodified":1566606400,
+    "wof:lastmodified":1582382267,
     "wof:name":"Gao",
     "wof:parent_id":85674521,
     "wof:placetype":"county",

--- a/data/890/418/903/890418903.geojson
+++ b/data/890/418/903/890418903.geojson
@@ -89,6 +89,9 @@
     },
     "wof:country":"ML",
     "wof:created":1469051266,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d4e77847484865cb074f4c55f86f76cb",
     "wof:hierarchy":[
         {
@@ -99,7 +102,7 @@
         }
     ],
     "wof:id":890418903,
-    "wof:lastmodified":1566606400,
+    "wof:lastmodified":1582382267,
     "wof:name":"Ansongo",
     "wof:parent_id":85674521,
     "wof:placetype":"county",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.