### PR TITLE
Update properties of megacities

### DIFF
--- a/data/421/182/167/421182167.geojson
+++ b/data/421/182/167/421182167.geojson
@@ -614,6 +614,7 @@
         "gn:id":2460596,
         "gp:id":1369729,
         "loc:id":"n50077818",
+        "ne:id":1159150945,
         "qs_pg:id":892309,
         "wd:id":"Q3703"
     },
@@ -636,7 +637,8 @@
         }
     ],
     "wof:id":421182167,
-    "wof:lastmodified":1607390884,
+    "wof:lastmodified":1608688178,
+    "wof:megacity":1,
     "wof:name":"Bamako",
     "wof:parent_id":421187095,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1547

- Updates megacity records with new:
  - concordances
  - names (if not already present)
  - label centroids
  - megacity flags
- Updates geometries of any megacity record with a `Point` geometry
- Updates parent geometries when necessary