### PR TITLE
ml concordances, placetype local, and more

### DIFF
--- a/data/110/856/281/7/1108562817.geojson
+++ b/data/110/856/281/7/1108562817.geojson
@@ -71,6 +71,7 @@
     "wof:concordances":{
         "hasc:id":"ML.SK.KD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ML",
     "wof:created":1474056837,
     "wof:geomhash":"6157c64a235ed559a641f51b67095433",
@@ -83,7 +84,7 @@
         }
     ],
     "wof:id":1108562817,
-    "wof:lastmodified":1694497832,
+    "wof:lastmodified":1695886811,
     "wof:name":"Kadiolo",
     "wof:parent_id":85674531,
     "wof:placetype":"county",

--- a/data/110/856/281/9/1108562819.geojson
+++ b/data/110/856/281/9/1108562819.geojson
@@ -81,6 +81,7 @@
     "wof:concordances":{
         "hasc:id":"ML.SK.KB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ML",
     "wof:created":1474056839,
     "wof:geomhash":"d696cb32725bd2a8e061565689b3922c",
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1108562819,
-    "wof:lastmodified":1694497832,
+    "wof:lastmodified":1695886811,
     "wof:name":"Kolondieba",
     "wof:parent_id":85674531,
     "wof:placetype":"county",

--- a/data/110/856/282/1/1108562821.geojson
+++ b/data/110/856/282/1/1108562821.geojson
@@ -65,6 +65,7 @@
     "wof:concordances":{
         "hasc:id":"ML.SK.YF"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ML",
     "wof:created":1474056840,
     "wof:geomhash":"fd438363ceb16a52c9fd1848e04fc2cd",
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108562821,
-    "wof:lastmodified":1694497832,
+    "wof:lastmodified":1695886812,
     "wof:name":"Yanfolila",
     "wof:parent_id":85674531,
     "wof:placetype":"county",

--- a/data/110/856/282/5/1108562825.geojson
+++ b/data/110/856/282/5/1108562825.geojson
@@ -164,6 +164,7 @@
     "wof:concordances":{
         "hasc:id":"ML.SK.SK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ML",
     "wof:created":1474056841,
     "wof:geomhash":"3baed8c48a889b38c6cd85ab13a825f1",
@@ -176,7 +177,7 @@
         }
     ],
     "wof:id":1108562825,
-    "wof:lastmodified":1694497832,
+    "wof:lastmodified":1695886812,
     "wof:name":"Sikasso",
     "wof:parent_id":85674531,
     "wof:placetype":"county",

--- a/data/110/856/282/7/1108562827.geojson
+++ b/data/110/856/282/7/1108562827.geojson
@@ -116,6 +116,7 @@
     "wof:concordances":{
         "hasc:id":"ML.KK.KG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ML",
     "wof:created":1474056842,
     "wof:geomhash":"fc1826573d88b1285610f2d1d84f913a",
@@ -128,7 +129,7 @@
         }
     ],
     "wof:id":1108562827,
-    "wof:lastmodified":1694498109,
+    "wof:lastmodified":1695886176,
     "wof:name":"Kangaba",
     "wof:parent_id":85674547,
     "wof:placetype":"county",

--- a/data/110/856/282/9/1108562829.geojson
+++ b/data/110/856/282/9/1108562829.geojson
@@ -125,6 +125,7 @@
     "wof:concordances":{
         "hasc:id":"ML.SK.BG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ML",
     "wof:created":1474056844,
     "wof:geomhash":"4af22ff306b10f55feacb9fa1067b249",
@@ -137,7 +138,7 @@
         }
     ],
     "wof:id":1108562829,
-    "wof:lastmodified":1694498109,
+    "wof:lastmodified":1695886175,
     "wof:name":"Bougouni",
     "wof:parent_id":85674531,
     "wof:placetype":"county",

--- a/data/110/856/283/1/1108562831.geojson
+++ b/data/110/856/283/1/1108562831.geojson
@@ -86,6 +86,7 @@
     "wof:concordances":{
         "hasc:id":"ML.SK.YR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ML",
     "wof:created":1474056845,
     "wof:geomhash":"cfb379f870072857947ac92dd8c99f99",
@@ -98,7 +99,7 @@
         }
     ],
     "wof:id":1108562831,
-    "wof:lastmodified":1694497833,
+    "wof:lastmodified":1695886812,
     "wof:name":"Yorosso",
     "wof:parent_id":85674531,
     "wof:placetype":"county",

--- a/data/110/856/283/3/1108562833.geojson
+++ b/data/110/856/283/3/1108562833.geojson
@@ -54,6 +54,7 @@
     "wof:concordances":{
         "hasc:id":"ML.KK.DL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ML",
     "wof:created":1474056847,
     "wof:geomhash":"ccfb8bd74108e0b0bbb0fa2b9a1bd76c",
@@ -66,7 +67,7 @@
         }
     ],
     "wof:id":1108562833,
-    "wof:lastmodified":1694498072,
+    "wof:lastmodified":1695886284,
     "wof:name":"Dioila",
     "wof:parent_id":85674547,
     "wof:placetype":"county",

--- a/data/110/856/283/5/1108562835.geojson
+++ b/data/110/856/283/5/1108562835.geojson
@@ -53,6 +53,7 @@
     "wof:concordances":{
         "hasc:id":"ML.SG.BL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ML",
     "wof:created":1474056848,
     "wof:geomhash":"67e5ddbdf3c46a358b2988bbecd7aa66",
@@ -65,7 +66,7 @@
         }
     ],
     "wof:id":1108562835,
-    "wof:lastmodified":1694498070,
+    "wof:lastmodified":1695886267,
     "wof:name":"Bla",
     "wof:parent_id":85674543,
     "wof:placetype":"county",

--- a/data/110/856/283/7/1108562837.geojson
+++ b/data/110/856/283/7/1108562837.geojson
@@ -54,6 +54,7 @@
     "wof:concordances":{
         "hasc:id":"ML.SG.BR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ML",
     "wof:created":1474056849,
     "wof:geomhash":"92a99affc3145dca76022060d53f7c96",
@@ -66,7 +67,7 @@
         }
     ],
     "wof:id":1108562837,
-    "wof:lastmodified":1694498070,
+    "wof:lastmodified":1695886255,
     "wof:name":"Baroueli",
     "wof:parent_id":85674543,
     "wof:placetype":"county",

--- a/data/110/856/283/9/1108562839.geojson
+++ b/data/110/856/283/9/1108562839.geojson
@@ -143,6 +143,7 @@
     "wof:concordances":{
         "hasc:id":"ML.KK.KK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ML",
     "wof:created":1474056851,
     "wof:geomhash":"6c5c5acd2d30f23bab4fd76fdc91e121",
@@ -155,7 +156,7 @@
         }
     ],
     "wof:id":1108562839,
-    "wof:lastmodified":1694498109,
+    "wof:lastmodified":1695886175,
     "wof:name":"Koulikoro",
     "wof:parent_id":85674547,
     "wof:placetype":"county",

--- a/data/110/856/284/3/1108562843.geojson
+++ b/data/110/856/284/3/1108562843.geojson
@@ -74,6 +74,7 @@
     "wof:concordances":{
         "hasc:id":"ML.SG.TM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ML",
     "wof:created":1474056852,
     "wof:geomhash":"621b60effd7876202320da1bb5ae9f32",
@@ -86,7 +87,7 @@
         }
     ],
     "wof:id":1108562843,
-    "wof:lastmodified":1694497832,
+    "wof:lastmodified":1695886811,
     "wof:name":"Tominian",
     "wof:parent_id":85674543,
     "wof:placetype":"county",

--- a/data/110/856/284/5/1108562845.geojson
+++ b/data/110/856/284/5/1108562845.geojson
@@ -77,6 +77,7 @@
     "wof:concordances":{
         "hasc:id":"ML.MO.BK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ML",
     "wof:created":1474056853,
     "wof:geomhash":"cfa0ad2c4e06b3744f66fad6e375bc17",
@@ -89,7 +90,7 @@
         }
     ],
     "wof:id":1108562845,
-    "wof:lastmodified":1694497832,
+    "wof:lastmodified":1695886812,
     "wof:name":"Bankass",
     "wof:parent_id":85674539,
     "wof:placetype":"county",

--- a/data/110/856/284/7/1108562847.geojson
+++ b/data/110/856/284/7/1108562847.geojson
@@ -119,6 +119,7 @@
     "wof:concordances":{
         "hasc:id":"ML.KY.KI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ML",
     "wof:created":1474056854,
     "wof:geomhash":"56aa51615706b8a89a07bcbc46e44c83",
@@ -131,7 +132,7 @@
         }
     ],
     "wof:id":1108562847,
-    "wof:lastmodified":1694498109,
+    "wof:lastmodified":1695886175,
     "wof:name":"Kita",
     "wof:parent_id":85674529,
     "wof:placetype":"county",

--- a/data/110/856/284/9/1108562849.geojson
+++ b/data/110/856/284/9/1108562849.geojson
@@ -92,6 +92,7 @@
     "wof:concordances":{
         "hasc:id":"ML.KK.KO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ML",
     "wof:created":1474056855,
     "wof:geomhash":"df5b4e41652cb0263f5f6f2265366c86",
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1108562849,
-    "wof:lastmodified":1694497832,
+    "wof:lastmodified":1695886812,
     "wof:name":"Kolokani",
     "wof:parent_id":85674547,
     "wof:placetype":"county",

--- a/data/110/856/285/1/1108562851.geojson
+++ b/data/110/856/285/1/1108562851.geojson
@@ -122,6 +122,7 @@
     "wof:concordances":{
         "hasc:id":"ML.KK.BB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ML",
     "wof:created":1474056857,
     "wof:geomhash":"6ba3555865896e5c7d535a64ad3e3e6c",
@@ -134,7 +135,7 @@
         }
     ],
     "wof:id":1108562851,
-    "wof:lastmodified":1694498109,
+    "wof:lastmodified":1695886176,
     "wof:name":"Banamba",
     "wof:parent_id":85674547,
     "wof:placetype":"county",

--- a/data/110/856/285/3/1108562853.geojson
+++ b/data/110/856/285/3/1108562853.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"ML.SG.MC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ML",
     "wof:created":1474056859,
     "wof:geomhash":"323f15ad4417ba5daf05a09b653e5c17",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108562853,
-    "wof:lastmodified":1694497833,
+    "wof:lastmodified":1695886812,
     "wof:name":"Macina",
     "wof:parent_id":85674543,
     "wof:placetype":"county",

--- a/data/110/856/285/5/1108562855.geojson
+++ b/data/110/856/285/5/1108562855.geojson
@@ -54,6 +54,7 @@
     "wof:concordances":{
         "hasc:id":"ML.KY.BF"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ML",
     "wof:created":1474056860,
     "wof:geomhash":"ab8c448853ef9408952174e94d406bef",
@@ -66,7 +67,7 @@
         }
     ],
     "wof:id":1108562855,
-    "wof:lastmodified":1694498070,
+    "wof:lastmodified":1695886251,
     "wof:name":"Bafoulabe",
     "wof:parent_id":85674529,
     "wof:placetype":"county",

--- a/data/110/856/285/7/1108562857.geojson
+++ b/data/110/856/285/7/1108562857.geojson
@@ -66,6 +66,7 @@
     "wof:concordances":{
         "hasc:id":"ML.KY.DM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ML",
     "wof:created":1474056862,
     "wof:geomhash":"6980784ae10067d70f385d3b4d15fcc5",
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1108562857,
-    "wof:lastmodified":1694498072,
+    "wof:lastmodified":1695886284,
     "wof:name":"Diema",
     "wof:parent_id":85674529,
     "wof:placetype":"county",

--- a/data/110/856/286/1/1108562861.geojson
+++ b/data/110/856/286/1/1108562861.geojson
@@ -54,6 +54,7 @@
     "wof:concordances":{
         "hasc:id":"ML.MO.TN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ML",
     "wof:created":1474056863,
     "wof:geomhash":"d53d397b884f9407a1d576772d152ebd",
@@ -66,7 +67,7 @@
         }
     ],
     "wof:id":1108562861,
-    "wof:lastmodified":1694498076,
+    "wof:lastmodified":1695886411,
     "wof:name":"Tenenkou",
     "wof:parent_id":85674539,
     "wof:placetype":"county",

--- a/data/110/856/286/3/1108562863.geojson
+++ b/data/110/856/286/3/1108562863.geojson
@@ -54,6 +54,7 @@
     "wof:concordances":{
         "hasc:id":"ML.KY.YL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ML",
     "wof:created":1474056864,
     "wof:geomhash":"8e4a9133163a0bb2ce76248743b8d4f3",
@@ -66,7 +67,7 @@
         }
     ],
     "wof:id":1108562863,
-    "wof:lastmodified":1694498077,
+    "wof:lastmodified":1695886430,
     "wof:name":"Yelimane",
     "wof:parent_id":85674529,
     "wof:placetype":"county",

--- a/data/110/856/286/5/1108562865.geojson
+++ b/data/110/856/286/5/1108562865.geojson
@@ -164,6 +164,7 @@
     "wof:concordances":{
         "hasc:id":"ML.KK.NA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ML",
     "wof:created":1474056865,
     "wof:geomhash":"a93814149b9d2fa75728f89efcfadf27",
@@ -176,7 +177,7 @@
         }
     ],
     "wof:id":1108562865,
-    "wof:lastmodified":1694498109,
+    "wof:lastmodified":1695886175,
     "wof:name":"Nara",
     "wof:parent_id":85674547,
     "wof:placetype":"county",

--- a/data/110/856/286/7/1108562867.geojson
+++ b/data/110/856/286/7/1108562867.geojson
@@ -80,6 +80,7 @@
     "wof:concordances":{
         "hasc:id":"ML.SG.NN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ML",
     "wof:created":1474056867,
     "wof:geomhash":"9a51e5025f8467236fcd2497148eaefc",
@@ -92,7 +93,7 @@
         }
     ],
     "wof:id":1108562867,
-    "wof:lastmodified":1694497832,
+    "wof:lastmodified":1695886811,
     "wof:name":"Niono",
     "wof:parent_id":85674543,
     "wof:placetype":"county",

--- a/data/110/856/286/9/1108562869.geojson
+++ b/data/110/856/286/9/1108562869.geojson
@@ -68,6 +68,7 @@
     "wof:concordances":{
         "hasc:id":"ML.KY.NR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ML",
     "wof:created":1474056868,
     "wof:geomhash":"bde643189824a252b056013adf75994d",
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108562869,
-    "wof:lastmodified":1694497832,
+    "wof:lastmodified":1695886811,
     "wof:name":"Nioro",
     "wof:parent_id":85674529,
     "wof:placetype":"county",

--- a/data/110/856/287/1/1108562871.geojson
+++ b/data/110/856/287/1/1108562871.geojson
@@ -71,6 +71,7 @@
     "wof:concordances":{
         "hasc:id":"ML.MO.YW"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ML",
     "wof:created":1474056869,
     "wof:geomhash":"480b62900a8b000cf40fd3bb18cf3dc9",
@@ -83,7 +84,7 @@
         }
     ],
     "wof:id":1108562871,
-    "wof:lastmodified":1694497832,
+    "wof:lastmodified":1695886811,
     "wof:name":"Youwarou",
     "wof:parent_id":85674539,
     "wof:placetype":"county",

--- a/data/110/856/287/3/1108562873.geojson
+++ b/data/110/856/287/3/1108562873.geojson
@@ -63,6 +63,7 @@
     "wof:concordances":{
         "hasc:id":"ML.TB.NF"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ML",
     "wof:created":1474056871,
     "wof:geomhash":"b97d3c4643386727c563511fe9baeafe",
@@ -75,7 +76,7 @@
         }
     ],
     "wof:id":1108562873,
-    "wof:lastmodified":1694497832,
+    "wof:lastmodified":1695886811,
     "wof:name":"Niafunke",
     "wof:parent_id":85674511,
     "wof:placetype":"county",

--- a/data/110/856/287/5/1108562875.geojson
+++ b/data/110/856/287/5/1108562875.geojson
@@ -96,6 +96,7 @@
     "wof:concordances":{
         "hasc:id":"ML.GA.MN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ML",
     "wof:created":1474056874,
     "wof:geomhash":"ff320ae93d8c9c4a7add4c306bd88223",
@@ -108,7 +109,7 @@
         }
     ],
     "wof:id":1108562875,
-    "wof:lastmodified":1694497832,
+    "wof:lastmodified":1695886811,
     "wof:name":"Menaka",
     "wof:parent_id":85674521,
     "wof:placetype":"county",

--- a/data/110/856/287/9/1108562879.geojson
+++ b/data/110/856/287/9/1108562879.geojson
@@ -116,6 +116,7 @@
     "wof:concordances":{
         "hasc:id":"ML.GA.BO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ML",
     "wof:created":1474056875,
     "wof:geomhash":"99da70382ad0979b88c78d27498eb5fb",
@@ -128,7 +129,7 @@
         }
     ],
     "wof:id":1108562879,
-    "wof:lastmodified":1694498109,
+    "wof:lastmodified":1695886175,
     "wof:name":"Bourem",
     "wof:parent_id":85674521,
     "wof:placetype":"county",

--- a/data/110/856/288/1/1108562881.geojson
+++ b/data/110/856/288/1/1108562881.geojson
@@ -74,6 +74,7 @@
     "wof:concordances":{
         "hasc:id":"ML.KD.TE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ML",
     "wof:created":1474056876,
     "wof:geomhash":"2524a2a83b7520280339efbcafcb121e",
@@ -86,7 +87,7 @@
         }
     ],
     "wof:id":1108562881,
-    "wof:lastmodified":1694497832,
+    "wof:lastmodified":1695886811,
     "wof:name":"Tin-Essako",
     "wof:parent_id":85674515,
     "wof:placetype":"county",

--- a/data/110/856/288/3/1108562883.geojson
+++ b/data/110/856/288/3/1108562883.geojson
@@ -146,6 +146,7 @@
     "wof:concordances":{
         "hasc:id":"ML.KD.KL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ML",
     "wof:created":1474056877,
     "wof:geomhash":"65d83d54d6d084f31e7d721d5d2c7f78",
@@ -158,7 +159,7 @@
         }
     ],
     "wof:id":1108562883,
-    "wof:lastmodified":1694498109,
+    "wof:lastmodified":1695886175,
     "wof:name":"Kidal",
     "wof:parent_id":85674515,
     "wof:placetype":"county",

--- a/data/110/856/288/5/1108562885.geojson
+++ b/data/110/856/288/5/1108562885.geojson
@@ -54,6 +54,7 @@
     "wof:concordances":{
         "hasc:id":"ML.KD.AB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ML",
     "wof:created":1474056878,
     "wof:geomhash":"d4d6c17f1ab306609ba73feedff0a276",
@@ -66,7 +67,7 @@
         }
     ],
     "wof:id":1108562885,
-    "wof:lastmodified":1694498069,
+    "wof:lastmodified":1695886246,
     "wof:name":"Abeibara",
     "wof:parent_id":85674515,
     "wof:placetype":"county",

--- a/data/110/856/288/7/1108562887.geojson
+++ b/data/110/856/288/7/1108562887.geojson
@@ -122,6 +122,7 @@
     "wof:concordances":{
         "hasc:id":"ML.KD.TS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ML",
     "wof:created":1474056879,
     "wof:geomhash":"c3cd4e8ea8444d581c5fc531eb7ba542",
@@ -134,7 +135,7 @@
         }
     ],
     "wof:id":1108562887,
-    "wof:lastmodified":1694498109,
+    "wof:lastmodified":1695886176,
     "wof:name":"Tessalit",
     "wof:parent_id":85674515,
     "wof:placetype":"county",

--- a/data/110/856/288/9/1108562889.geojson
+++ b/data/110/856/288/9/1108562889.geojson
@@ -116,6 +116,7 @@
     "wof:concordances":{
         "hasc:id":"ML.TB.GD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ML",
     "wof:created":1474056880,
     "wof:geomhash":"75898c06988b7e29a804843d42701fd9",
@@ -128,7 +129,7 @@
         }
     ],
     "wof:id":1108562889,
-    "wof:lastmodified":1694498109,
+    "wof:lastmodified":1695886175,
     "wof:name":"Goundam",
     "wof:parent_id":85674511,
     "wof:placetype":"county",

--- a/data/110/856/289/1/1108562891.geojson
+++ b/data/110/856/289/1/1108562891.geojson
@@ -59,6 +59,7 @@
     "wof:concordances":{
         "hasc:id":"ML.TB.TB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ML",
     "wof:created":1474056881,
     "wof:geomhash":"db03dc5446193dfb5079b00cd2881711",
@@ -71,7 +72,7 @@
         }
     ],
     "wof:id":1108562891,
-    "wof:lastmodified":1694497832,
+    "wof:lastmodified":1695886811,
     "wof:name":"Tombouctou",
     "wof:parent_id":85674511,
     "wof:placetype":"county",

--- a/data/421/171/549/421171549.geojson
+++ b/data/421/171/549/421171549.geojson
@@ -149,6 +149,7 @@
         "wd:id":"Q1538145",
         "wk:page":"Kayes Cercle"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ML",
     "wof:created":1459008897,
     "wof:geom_alt":[
@@ -164,7 +165,7 @@
         }
     ],
     "wof:id":421171549,
-    "wof:lastmodified":1694492944,
+    "wof:lastmodified":1695886176,
     "wof:name":"Kayes",
     "wof:parent_id":85674529,
     "wof:placetype":"county",

--- a/data/421/171/903/421171903.geojson
+++ b/data/421/171/903/421171903.geojson
@@ -93,6 +93,7 @@
         "hasc:id":"ML.KY.KN",
         "qs_pg:id":1280452
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ML",
     "wof:created":1459008911,
     "wof:geom_alt":[
@@ -108,7 +109,7 @@
         }
     ],
     "wof:id":421171903,
-    "wof:lastmodified":1694492504,
+    "wof:lastmodified":1695886133,
     "wof:name":"Kenieba",
     "wof:parent_id":85674529,
     "wof:placetype":"county",

--- a/data/421/171/975/421171975.geojson
+++ b/data/421/171/975/421171975.geojson
@@ -119,6 +119,7 @@
         "wd:id":"Q806313",
         "wk:page":"Bandiagara Cercle"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ML",
     "wof:created":1459008914,
     "wof:geom_alt":[
@@ -134,7 +135,7 @@
         }
     ],
     "wof:id":421171975,
-    "wof:lastmodified":1694492704,
+    "wof:lastmodified":1695886798,
     "wof:name":"Bandiagara",
     "wof:parent_id":85674539,
     "wof:placetype":"county",

--- a/data/421/172/359/421172359.geojson
+++ b/data/421/172/359/421172359.geojson
@@ -133,6 +133,7 @@
         "qs_pg:id":1306622,
         "wd:id":"Q2429438"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ML",
     "wof:created":1459008937,
     "wof:geom_alt":[
@@ -148,7 +149,7 @@
         }
     ],
     "wof:id":421172359,
-    "wof:lastmodified":1694492504,
+    "wof:lastmodified":1695886134,
     "wof:name":"Dire",
     "wof:parent_id":85674511,
     "wof:placetype":"county",

--- a/data/421/175/221/421175221.geojson
+++ b/data/421/175/221/421175221.geojson
@@ -109,6 +109,7 @@
         "hasc:id":"ML.SG.SG",
         "qs_pg:id":361585
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ML",
     "wof:created":1459009060,
     "wof:geom_alt":[
@@ -124,7 +125,7 @@
         }
     ],
     "wof:id":421175221,
-    "wof:lastmodified":1694492704,
+    "wof:lastmodified":1695886799,
     "wof:name":"Segou",
     "wof:parent_id":85674543,
     "wof:placetype":"county",

--- a/data/421/177/883/421177883.geojson
+++ b/data/421/177/883/421177883.geojson
@@ -104,6 +104,7 @@
         "hasc:id":"ML.KK.KT",
         "qs_pg:id":1355212
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ML",
     "wof:created":1459009163,
     "wof:geom_alt":[
@@ -119,7 +120,7 @@
         }
     ],
     "wof:id":421177883,
-    "wof:lastmodified":1694492944,
+    "wof:lastmodified":1695886176,
     "wof:name":"Kati",
     "wof:parent_id":85674547,
     "wof:placetype":"county",

--- a/data/421/177/885/421177885.geojson
+++ b/data/421/177/885/421177885.geojson
@@ -214,6 +214,7 @@
         "qs_pg:id":1355217,
         "wd:id":"Q281000"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ML",
     "wof:created":1459009163,
     "wof:geom_alt":[
@@ -229,7 +230,7 @@
         }
     ],
     "wof:id":421177885,
-    "wof:lastmodified":1694492944,
+    "wof:lastmodified":1695886176,
     "wof:name":"Koutiala",
     "wof:parent_id":85674531,
     "wof:placetype":"county",

--- a/data/421/180/081/421180081.geojson
+++ b/data/421/180/081/421180081.geojson
@@ -122,6 +122,7 @@
         "wd:id":"Q1816378",
         "wk:page":"Mopti Cercle"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ML",
     "wof:created":1459009243,
     "wof:geom_alt":[
@@ -137,7 +138,7 @@
         }
     ],
     "wof:id":421180081,
-    "wof:lastmodified":1694492944,
+    "wof:lastmodified":1695886176,
     "wof:name":"Mopti",
     "wof:parent_id":85674539,
     "wof:placetype":"county",

--- a/data/421/184/495/421184495.geojson
+++ b/data/421/184/495/421184495.geojson
@@ -126,6 +126,7 @@
         "hasc:id":"ML.MO.KR",
         "qs_pg:id":1000655
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ML",
     "wof:created":1459009412,
     "wof:geom_alt":[
@@ -141,7 +142,7 @@
         }
     ],
     "wof:id":421184495,
-    "wof:lastmodified":1694492504,
+    "wof:lastmodified":1695886134,
     "wof:name":"Koro",
     "wof:parent_id":85674539,
     "wof:placetype":"county",

--- a/data/421/187/097/421187097.geojson
+++ b/data/421/187/097/421187097.geojson
@@ -250,6 +250,7 @@
         "qs_pg:id":1080270,
         "wd:id":"Q213507"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ML",
     "wof:created":1459009502,
     "wof:geom_alt":[
@@ -265,7 +266,7 @@
         }
     ],
     "wof:id":421187097,
-    "wof:lastmodified":1694492504,
+    "wof:lastmodified":1695886134,
     "wof:name":"Djenne",
     "wof:parent_id":85674539,
     "wof:placetype":"county",

--- a/data/421/192/717/421192717.geojson
+++ b/data/421/192/717/421192717.geojson
@@ -110,6 +110,7 @@
         "hasc:id":"ML.SG.SN",
         "qs_pg:id":1174430
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ML",
     "wof:created":1459009746,
     "wof:geom_alt":[
@@ -125,7 +126,7 @@
         }
     ],
     "wof:id":421192717,
-    "wof:lastmodified":1694492944,
+    "wof:lastmodified":1695886176,
     "wof:name":"San",
     "wof:parent_id":85674543,
     "wof:placetype":"county",

--- a/data/421/199/983/421199983.geojson
+++ b/data/421/199/983/421199983.geojson
@@ -111,6 +111,7 @@
         "wd:id":"Q940936",
         "wk:page":"Douentza Cercle"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ML",
     "wof:created":1459010007,
     "wof:geom_alt":[
@@ -126,7 +127,7 @@
         }
     ],
     "wof:id":421199983,
-    "wof:lastmodified":1694492705,
+    "wof:lastmodified":1695886799,
     "wof:name":"Douentza",
     "wof:parent_id":85674539,
     "wof:placetype":"county",

--- a/data/856/325/53/85632553.geojson
+++ b/data/856/325/53/85632553.geojson
@@ -1107,6 +1107,7 @@
         "hasc:id":"ML",
         "icao:code":"TZ",
         "ioc:id":"MLI",
+        "iso:code":"ML",
         "itu:id":"MLI",
         "loc:id":"n79007504",
         "m49:code":"466",
@@ -1121,6 +1122,7 @@
         "wk:page":"Mali",
         "wmo:id":"MI"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"ML",
     "wof:country_alpha3":"MLI",
     "wof:geom_alt":[
@@ -1142,7 +1144,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1694639670,
+    "wof:lastmodified":1695881330,
     "wof:name":"Mali",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/745/11/85674511.geojson
+++ b/data/856/745/11/85674511.geojson
@@ -309,11 +309,13 @@
         "gn:id":2449066,
         "gp:id":2346187,
         "hasc:id":"ML.TT",
+        "iso:code":"ML-6",
         "qs_pg:id":1083848,
         "unlc:id":"ML-6",
         "wd:id":"Q339462",
         "wk:page":"Tombouctou Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"ML",
     "wof:geom_alt":[
         "quattroshapes"
@@ -333,7 +335,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1694493263,
+    "wof:lastmodified":1695885131,
     "wof:name":"Timbuktu",
     "wof:parent_id":85632553,
     "wof:placetype":"region",

--- a/data/856/745/15/85674515.geojson
+++ b/data/856/745/15/85674515.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":12.919892,
-    "geom:area_square_m":150599119281.568024,
+    "geom:area_square_m":150599123031.34137,
     "geom:bbox":"-2.056434,17.699571,4.243286,21.906471",
     "geom:latitude":19.473921,
     "geom:longitude":1.107205,
@@ -301,17 +301,19 @@
         "gn:id":2597449,
         "gp:id":55999799,
         "hasc:id":"ML.KD",
+        "iso:code":"ML-8",
         "iso:id":"ML-8",
         "qs_pg:id":1188019,
         "unlc:id":"ML-8",
         "wd:id":"Q338988",
         "wk:page":"Kidal Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"ML",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d9fc90032eb41bcdb5ffb995daa3ea77",
+    "wof:geomhash":"818854218492070c799232dba017fcbe",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -326,7 +328,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1690939602,
+    "wof:lastmodified":1695884966,
     "wof:name":"Kidal",
     "wof:parent_id":85632553,
     "wof:placetype":"region",

--- a/data/856/745/21/85674521.geojson
+++ b/data/856/745/21/85674521.geojson
@@ -295,10 +295,12 @@
         "gn:id":2457161,
         "gp:id":2346181,
         "hasc:id":"ML.GO",
+        "iso:code":"ML-7",
         "qs_pg:id":219576,
         "wd:id":"Q332392",
         "wk:page":"Gao Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"ML",
     "wof:geom_alt":[
         "quattroshapes"
@@ -318,7 +320,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1694493261,
+    "wof:lastmodified":1695884966,
     "wof:name":"Gao",
     "wof:parent_id":85632553,
     "wof:placetype":"region",

--- a/data/856/745/25/85674525.geojson
+++ b/data/856/745/25/85674525.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.020378,
-    "geom:area_square_m":245901360.24172,
+    "geom:area_square_m":245901384.308007,
     "geom:bbox":"-8.081421,12.50293,-7.91217,12.711487",
     "geom:latitude":12.609092,
     "geom:longitude":-7.980004,
@@ -618,12 +618,14 @@
         "gn:id":2460594,
         "gp:id":2346180,
         "hasc:id":"ML.BA",
+        "iso:code":"ML-BKO",
         "iso:id":"ML-BKO",
         "qs_pg:id":219575,
         "unlc:id":"ML-BKO",
         "wd:id":"Q3703",
         "wk:page":"Bamako"
     },
+    "wof:concordances_official":"iso:code",
     "wof:coterminous":[
         421182167
     ],
@@ -631,7 +633,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"10d4dece69863efabe7c5ed160dbbdf0",
+    "wof:geomhash":"21517c6c39fa659e2ec9bc81d76a5b0e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -646,7 +648,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1690939603,
+    "wof:lastmodified":1695884382,
     "wof:name":"Bamako",
     "wof:parent_id":85632553,
     "wof:placetype":"region",

--- a/data/856/745/29/85674529.geojson
+++ b/data/856/745/29/85674529.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":10.248419,
-    "geom:area_square_m":123009586219.302063,
+    "geom:area_square_m":123009565322.814911,
     "geom:bbox":"-12.235756,11.894104,-8.132334,15.692322",
     "geom:latitude":13.876691,
     "geom:longitude":-10.229281,
@@ -312,17 +312,19 @@
         "gn:id":2455517,
         "gp:id":2346182,
         "hasc:id":"ML.KY",
+        "iso:code":"ML-1",
         "iso:id":"ML-1",
         "qs_pg:id":219577,
         "unlc:id":"ML-1",
         "wd:id":"Q332113",
         "wk:page":"Kayes Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"ML",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"2c7775fcffb9d45322fba556f5207559",
+    "wof:geomhash":"817c1cd1fda14d61c44b70aa990983d4",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -337,7 +339,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1690939601,
+    "wof:lastmodified":1695884966,
     "wof:name":"Kayes",
     "wof:parent_id":85632553,
     "wof:placetype":"region",

--- a/data/856/745/31/85674531.geojson
+++ b/data/856/745/31/85674531.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":5.941713,
-    "geom:area_square_m":72010664201.679611,
+    "geom:area_square_m":72010649205.759155,
     "geom:bbox":"-8.679504,10.141479,-4.367371,12.814471",
     "geom:latitude":11.422754,
     "geom:longitude":-6.551422,
@@ -309,17 +309,19 @@
         "gn:id":2451184,
         "gp:id":2346185,
         "hasc:id":"ML.SK",
+        "iso:code":"ML-3",
         "iso:id":"ML-3",
         "qs_pg:id":493841,
         "unlc:id":"ML-3",
         "wd:id":"Q461298",
         "wk:page":"Sikasso Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"ML",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"85012b07e0648667b47c67ea26ccfbc1",
+    "wof:geomhash":"6ec307277d10d99da892f05869fa406e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -334,7 +336,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1690939602,
+    "wof:lastmodified":1695885133,
     "wof:name":"Sikasso",
     "wof:parent_id":85632553,
     "wof:placetype":"region",

--- a/data/856/745/39/85674539.geojson
+++ b/data/856/745/39/85674539.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":6.64745,
-    "geom:area_square_m":79505879083.478195,
+    "geom:area_square_m":79505857192.711975,
     "geom:bbox":"-5.665527,13.152893,-0.743713,15.897971",
     "geom:latitude":14.69126,
     "geom:longitude":-3.553465,
@@ -312,17 +312,19 @@
         "gn:id":2453347,
         "gp:id":2346183,
         "hasc:id":"ML.MO",
+        "iso:code":"ML-5",
         "iso:id":"ML-5",
         "qs_pg:id":219578,
         "unlc:id":"ML-5",
         "wd:id":"Q214155",
         "wk:page":"Mopti Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"ML",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d449ceb8a766dca4c31d8f323fa84b9e",
+    "wof:geomhash":"1d0f941a7c07979e7682fcd7bc7739f2",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -337,7 +339,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1690939602,
+    "wof:lastmodified":1695884966,
     "wof:name":"Mopti",
     "wof:parent_id":85632553,
     "wof:placetype":"region",

--- a/data/856/745/43/85674543.geojson
+++ b/data/856/745/43/85674543.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":5.182998,
-    "geom:area_square_m":62230997446.94545,
+    "geom:area_square_m":62231012487.798042,
     "geom:bbox":"-7.081334,12.545871,-3.958374,15.551304",
     "geom:latitude":13.807956,
     "geom:longitude":-5.698426,
@@ -305,17 +305,19 @@
         "gn:id":2451477,
         "gp:id":2346184,
         "hasc:id":"ML.SG",
+        "iso:code":"ML-4",
         "iso:id":"ML-4",
         "qs_pg:id":423828,
         "unlc:id":"ML-4",
         "wd:id":"Q656845",
         "wk:page":"S\u00e9gou Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"ML",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"26e0fd774d17ec0a042a118511296c4b",
+    "wof:geomhash":"72a1b3b53ccd2d78bf0bfe7ee5261a6e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -330,7 +332,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1690939601,
+    "wof:lastmodified":1695884523,
     "wof:name":"S\u00e9gou",
     "wof:parent_id":85632553,
     "wof:placetype":"region",

--- a/data/856/745/47/85674547.geojson
+++ b/data/856/745/47/85674547.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":7.564615,
-    "geom:area_square_m":90888107360.312485,
+    "geom:area_square_m":90888111060.598206,
     "geom:bbox":"-9.135433,11.456299,-5.964334,15.498474",
     "geom:latitude":13.623468,
     "geom:longitude":-7.644304,
@@ -303,6 +303,7 @@
         "gn:id":2454532,
         "gp:id":2346186,
         "hasc:id":"ML.KK",
+        "iso:code":"ML-2",
         "iso:id":"ML-2",
         "loc:id":"n85160174",
         "qs_pg:id":1083846,
@@ -310,11 +311,12 @@
         "wd:id":"Q287789",
         "wk:page":"Koulikoro Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"ML",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"0a863040a8e4f01ef01e26f3de431531",
+    "wof:geomhash":"bfa8ef972c88829646b2d71f5cfa275d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -329,7 +331,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1690939603,
+    "wof:lastmodified":1695884966,
     "wof:name":"Koulikoro",
     "wof:parent_id":85632553,
     "wof:placetype":"region",

--- a/data/890/418/895/890418895.geojson
+++ b/data/890/418/895/890418895.geojson
@@ -102,6 +102,7 @@
         "wd:id":"Q1540214",
         "wk:page":"Gourma-Rharous Cercle"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ML",
     "wof:created":1469051265,
     "wof:geom_alt":[
@@ -117,7 +118,7 @@
         }
     ],
     "wof:id":890418895,
-    "wof:lastmodified":1694639720,
+    "wof:lastmodified":1695886799,
     "wof:name":"Gourma-Rharous",
     "wof:parent_id":85674511,
     "wof:placetype":"county",

--- a/data/890/418/899/890418899.geojson
+++ b/data/890/418/899/890418899.geojson
@@ -102,6 +102,7 @@
         "wd:id":"Q1493783",
         "wk:page":"Gao Cercle"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ML",
     "wof:created":1469051265,
     "wof:geom_alt":[
@@ -117,7 +118,7 @@
         }
     ],
     "wof:id":890418899,
-    "wof:lastmodified":1694498109,
+    "wof:lastmodified":1695886177,
     "wof:name":"Gao",
     "wof:parent_id":85674521,
     "wof:placetype":"county",

--- a/data/890/418/903/890418903.geojson
+++ b/data/890/418/903/890418903.geojson
@@ -96,6 +96,7 @@
         "wd:id":"Q570016",
         "wk:page":"Ansongo Cercle"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ML",
     "wof:created":1469051266,
     "wof:geom_alt":[
@@ -111,7 +112,7 @@
         }
     ],
     "wof:id":890418903,
-    "wof:lastmodified":1694639689,
+    "wof:lastmodified":1695886134,
     "wof:name":"Ansongo",
     "wof:parent_id":85674521,
     "wof:placetype":"county",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.